### PR TITLE
Add Chinese music sources support for mainland China users

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ That means, in the upcoming new versions, you will no longer be able to login wi
   <img width="600" src="assets/spotube_banner.png" alt="Spotube Logo">
 
 An open source, cross-platform music client<br />
-utilizing selected music provider API and YouTube®, Piped.video or JioSaavn as an audio source
+utilizing selected music provider API and YouTube®, Piped.video, JioSaavn or Chinese music platforms (酷我音乐, 酷狗音乐, QQ音乐, 网易音乐, 咪咕音乐) as an audio source
 
 Btw it's not just another Electron app 😉
 

--- a/docs/chinese_music_sources.md
+++ b/docs/chinese_music_sources.md
@@ -1,0 +1,82 @@
+# Chinese Music Sources for Spotube
+
+This document explains how to use Chinese music platforms as audio sources in Spotube, allowing users in mainland China to access music.
+
+## Supported Platforms
+
+Spotube now supports the following Chinese music platforms:
+
+- 酷我音乐 (KW)
+- 酷狗音乐 (KG)
+- QQ音乐 (TX)
+- 网易音乐 (WY)
+- 咪咕音乐 (MG)
+
+## Setup
+
+### 1. Select a Chinese Music Platform
+
+In Spotube settings, go to the "Playback" section and select one of the Chinese music platforms as your audio source.
+
+### 2. Configure API Proxy (Optional)
+
+For better performance and reliability, you can set up a proxy server that handles requests to Chinese music platforms. This is especially useful if you're experiencing connection issues.
+
+1. In the settings, under the Chinese music platform section, click the edit button next to "音乐API代理"
+2. Enter the URL of your proxy server
+3. Click "Save"
+
+## Setting Up Your Own Proxy Server
+
+The Chinese music sources in Spotube require a proxy server to handle API requests to Chinese music platforms. You have two options:
+
+### Option 1: Use lx-music-api-server (Recommended)
+
+1. Clone the [lx-music-api-server](https://github.com/lyswhut/lx-music-api-server) repository
+2. Follow the installation instructions in the repository
+3. Configure the server to listen on a publicly accessible URL
+4. Enter this URL in Spotube's settings
+
+### Option 2: Create Your Own Proxy Server
+
+We've provided a simple example implementation in `docs/proxy_server_example.js` that demonstrates the API structure required by Spotube. To use it:
+
+1. Install Node.js if you don't have it already
+2. Create a new directory for your proxy server
+3. Copy the example file and install dependencies:
+   ```bash
+   npm init -y
+   npm install express cors axios crypto
+   node proxy_server_example.js
+   ```
+4. Modify the placeholder functions to implement the actual API calls to Chinese music platforms
+5. Deploy the server to a publicly accessible URL
+6. Enter this URL in Spotube's settings
+
+The example server implements the following endpoints:
+- `GET /status` - Check if the server is running
+- `POST /search` - Search for music on a specific platform
+- `POST /url` - Get the streaming URL for a song
+- `POST /lyric` - Get lyrics for a song
+
+## How It Works
+
+When you play a track in Spotube with a Chinese music source selected:
+
+1. Spotube searches for the track on the selected Chinese music platform
+2. It retrieves the audio URL and metadata from the platform
+3. The audio is streamed directly from the Chinese platform's servers
+
+This allows users in mainland China to access music without requiring a VPN or other circumvention tools.
+
+## Troubleshooting
+
+If you encounter issues:
+
+1. Make sure your proxy server is correctly configured and accessible
+2. Try a different Chinese music platform as some may have better availability for certain tracks
+3. Check your internet connection to ensure it can access Chinese websites
+
+## Credits
+
+This feature was inspired by and adapted from the [lx-music-desktop](https://github.com/lyswhut/lx-music-desktop) project.

--- a/docs/proxy_server_example.js
+++ b/docs/proxy_server_example.js
@@ -1,0 +1,265 @@
+// Example proxy server for Chinese music platforms
+// This is a simple implementation to demonstrate the API structure
+// For production use, consider using the lx-music-api-server project
+
+const express = require('express');
+const cors = require('cors');
+const axios = require('axios');
+const crypto = require('crypto');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Secret key for signature verification
+const SECRET_KEY = 'your_secret_key'; // Change this in production
+
+// Middleware
+app.use(express.json());
+app.use(cors());
+
+// Verify request signature
+function verifySignature(req, res, next) {
+  const { timestamp, ...params } = req.body;
+  const signature = req.headers['x-signature'];
+  
+  if (!timestamp || !signature) {
+    return res.status(401).json({ error: 'Missing timestamp or signature' });
+  }
+  
+  // Sort params alphabetically
+  const sortedKeys = Object.keys(params).sort();
+  const sortedParams = {};
+  for (const key of sortedKeys) {
+    sortedParams[key] = params[key];
+  }
+  
+  // Create signature string
+  const paramsString = Object.entries(sortedParams)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
+  
+  const signString = `${paramsString}&timestamp=${timestamp}`;
+  
+  // Generate HMAC-SHA256
+  const hmac = crypto.createHmac('sha256', SECRET_KEY);
+  hmac.update(signString);
+  const calculatedSignature = hmac.digest('hex');
+  
+  if (calculatedSignature !== signature) {
+    return res.status(401).json({ error: 'Invalid signature' });
+  }
+  
+  next();
+}
+
+// Status endpoint (no auth required)
+app.get('/status', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+// Search endpoint
+app.post('/search', verifySignature, async (req, res) => {
+  try {
+    const { platform, keyword, page = 1, limit = 10 } = req.body;
+    
+    // Implement platform-specific search logic
+    let result;
+    switch (platform) {
+      case 'kw': // 酷我音乐
+        result = await searchKuwo(keyword, page, limit);
+        break;
+      case 'kg': // 酷狗音乐
+        result = await searchKugou(keyword, page, limit);
+        break;
+      case 'tx': // QQ音乐
+        result = await searchQQ(keyword, page, limit);
+        break;
+      case 'wy': // 网易音乐
+        result = await searchNetease(keyword, page, limit);
+        break;
+      case 'mg': // 咪咕音乐
+        result = await searchMigu(keyword, page, limit);
+        break;
+      default:
+        return res.status(400).json({ error: 'Unsupported platform' });
+    }
+    
+    res.json(result);
+  } catch (error) {
+    console.error('Search error:', error);
+    res.status(500).json({ error: 'Search failed', message: error.message });
+  }
+});
+
+// URL endpoint
+app.post('/url', verifySignature, async (req, res) => {
+  try {
+    const { platform, songId, quality } = req.body;
+    
+    // Implement platform-specific URL retrieval logic
+    let result;
+    switch (platform) {
+      case 'kw': // 酷我音乐
+        result = await getKuwoUrl(songId, quality);
+        break;
+      case 'kg': // 酷狗音乐
+        result = await getKugouUrl(songId, quality);
+        break;
+      case 'tx': // QQ音乐
+        result = await getQQUrl(songId, quality);
+        break;
+      case 'wy': // 网易音乐
+        result = await getNeteaseUrl(songId, quality);
+        break;
+      case 'mg': // 咪咕音乐
+        result = await getMiguUrl(songId, quality);
+        break;
+      default:
+        return res.status(400).json({ error: 'Unsupported platform' });
+    }
+    
+    res.json(result);
+  } catch (error) {
+    console.error('URL error:', error);
+    res.status(500).json({ error: 'Failed to get URL', message: error.message });
+  }
+});
+
+// Lyric endpoint
+app.post('/lyric', verifySignature, async (req, res) => {
+  try {
+    const { platform, songId } = req.body;
+    
+    // Implement platform-specific lyric retrieval logic
+    let result;
+    switch (platform) {
+      case 'kw': // 酷我音乐
+        result = await getKuwoLyric(songId);
+        break;
+      case 'kg': // 酷狗音乐
+        result = await getKugouLyric(songId);
+        break;
+      case 'tx': // QQ音乐
+        result = await getQQLyric(songId);
+        break;
+      case 'wy': // 网易音乐
+        result = await getNeteaseLyric(songId);
+        break;
+      case 'mg': // 咪咕音乐
+        result = await getMiguLyric(songId);
+        break;
+      default:
+        return res.status(400).json({ error: 'Unsupported platform' });
+    }
+    
+    res.json(result);
+  } catch (error) {
+    console.error('Lyric error:', error);
+    res.status(500).json({ error: 'Failed to get lyric', message: error.message });
+  }
+});
+
+// Start server
+app.listen(PORT, () => {
+  console.log(`Proxy server running on port ${PORT}`);
+});
+
+// ===== Platform-specific implementations =====
+// These are placeholder functions. In a real implementation,
+// you would need to implement the actual API calls to each platform.
+
+// Kuwo (酷我音乐)
+async function searchKuwo(keyword, page, limit) {
+  // Implement Kuwo search API
+  // This is a placeholder - you need to implement the actual API call
+  return {
+    list: [
+      {
+        songmid: 'example_id',
+        name: 'Example Song',
+        singer: 'Example Artist',
+        duration: '180000',
+        pic: 'https://example.com/image.jpg',
+      }
+    ],
+    total: 1,
+  };
+}
+
+async function getKuwoUrl(songId, quality) {
+  // Implement Kuwo URL API
+  return {
+    url: 'https://example.com/song.mp3',
+  };
+}
+
+async function getKuwoLyric(songId) {
+  // Implement Kuwo lyric API
+  return {
+    lyric: '[00:00.00]Example lyrics',
+  };
+}
+
+// Kugou (酷狗音乐)
+async function searchKugou(keyword, page, limit) {
+  // Implement Kugou search API
+  return { list: [], total: 0 };
+}
+
+async function getKugouUrl(songId, quality) {
+  // Implement Kugou URL API
+  return { url: '' };
+}
+
+async function getKugouLyric(songId) {
+  // Implement Kugou lyric API
+  return { lyric: '' };
+}
+
+// QQ Music (QQ音乐)
+async function searchQQ(keyword, page, limit) {
+  // Implement QQ Music search API
+  return { list: [], total: 0 };
+}
+
+async function getQQUrl(songId, quality) {
+  // Implement QQ Music URL API
+  return { url: '' };
+}
+
+async function getQQLyric(songId) {
+  // Implement QQ Music lyric API
+  return { lyric: '' };
+}
+
+// Netease (网易音乐)
+async function searchNetease(keyword, page, limit) {
+  // Implement Netease search API
+  return { list: [], total: 0 };
+}
+
+async function getNeteaseUrl(songId, quality) {
+  // Implement Netease URL API
+  return { url: '' };
+}
+
+async function getNeteaseLyric(songId) {
+  // Implement Netease lyric API
+  return { lyric: '' };
+}
+
+// Migu (咪咕音乐)
+async function searchMigu(keyword, page, limit) {
+  // Implement Migu search API
+  return { list: [], total: 0 };
+}
+
+async function getMiguUrl(songId, quality) {
+  // Implement Migu URL API
+  return { url: '' };
+}
+
+async function getMiguLyric(songId) {
+  // Implement Migu lyric API
+  return { lyric: '' };
+}

--- a/lib/models/database/tables/preferences.dart
+++ b/lib/models/database/tables/preferences.dart
@@ -15,9 +15,22 @@ enum AudioSource {
   youtube,
   piped,
   jiosaavn,
-  invidious;
+  invidious,
+  // Chinese music platforms
+  kw, // 酷我音乐
+  kg, // 酷狗音乐
+  tx, // QQ音乐
+  wy, // 网易音乐
+  mg; // 咪咕音乐
 
-  String get label => name[0].toUpperCase() + name.substring(1);
+  String get label => switch (this) {
+    AudioSource.kw => "酷我音乐",
+    AudioSource.kg => "酷狗音乐",
+    AudioSource.tx => "QQ音乐",
+    AudioSource.wy => "网易音乐",
+    AudioSource.mg => "咪咕音乐",
+    _ => name[0].toUpperCase() + name.substring(1),
+  };
 }
 
 enum YoutubeClientEngine {
@@ -99,6 +112,8 @@ class PreferencesTable extends Table {
       text().withDefault(const Constant("https://pipedapi.kavin.rocks"))();
   TextColumn get invidiousInstance =>
       text().withDefault(const Constant("https://inv.nadeko.net"))();
+  TextColumn get chineseMusicProxyUrl =>
+      text().nullable()();
   TextColumn get themeMode =>
       textEnum<ThemeMode>().withDefault(Constant(ThemeMode.system.name))();
   TextColumn get audioSource =>
@@ -140,6 +155,7 @@ class PreferencesTable extends Table {
       localLibraryLocation: [],
       pipedInstance: "https://pipedapi.kavin.rocks",
       invidiousInstance: "https://inv.nadeko.net",
+      chineseMusicProxyUrl: null,
       themeMode: ThemeMode.system,
       audioSource: AudioSource.youtube,
       youtubeClientEngine: YoutubeClientEngine.youtubeExplode,

--- a/lib/pages/settings/sections/playback.dart
+++ b/lib/pages/settings/sections/playback.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:auto_route/auto_route.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart' show ListTile;
+import 'package:flutter/material.dart' show ListTile, Colors;
 
 import 'package:google_fonts/google_fonts.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -18,6 +18,7 @@ import 'package:spotube/modules/settings/section_card_with_heading.dart';
 import 'package:spotube/components/adaptive/adaptive_select_tile.dart';
 import 'package:spotube/extensions/context.dart';
 import 'package:spotube/modules/settings/youtube_engine_not_installed_dialog.dart';
+import 'package:spotube/services/chinese_music_proxy/chinese_music_proxy.dart';
 import 'package:spotube/provider/audio_player/sources/invidious_instances_provider.dart';
 import 'package:spotube/provider/audio_player/sources/piped_instances_provider.dart';
 import 'package:spotube/provider/user_preferences/user_preferences_provider.dart';
@@ -330,6 +331,83 @@ class SettingsPlaybackSection extends HookConsumerWidget {
                 if (value == null) return;
                 preferencesNotifier.setSearchMode(value);
               },
+            ),
+          // Chinese music platforms section
+          AudioSource.kw ||
+          AudioSource.kg ||
+          AudioSource.tx ||
+          AudioSource.wy ||
+          AudioSource.mg => Column(
+              children: [
+                ListTile(
+                  leading: const Icon(SpotubeIcons.info),
+                  title: Text("中国音乐平台"),
+                  subtitle: Text("使用中国音乐平台作为音源，可以在中国大陆使用Spotube"),
+                ),
+                Consumer(
+                  builder: (context, ref, _) {
+                    final proxy = ref.watch(chineseMusicProxyProvider);
+                    final proxyStatus = ref.watch(
+                      FutureProvider((ref) => proxy.checkProxyStatus()),
+                    );
+                    
+                    return ListTile(
+                      leading: const Icon(SpotubeIcons.api),
+                      title: Text("音乐API代理"),
+                      subtitle: Text(preferences.chineseMusicProxyUrl ?? "未设置"),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          proxyStatus.when(
+                            data: (isWorking) => Container(
+                              width: 12,
+                              height: 12,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: isWorking ? Colors.green : Colors.red,
+                              ),
+                            ),
+                            loading: () => const SizedBox(
+                              width: 12,
+                              height: 12,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            ),
+                            error: (_, __) => Container(
+                              width: 12,
+                              height: 12,
+                              decoration: const BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Colors.red,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          IconButton.outline(
+                            icon: const Icon(SpotubeIcons.edit),
+                            size: ButtonSize.small,
+                            onPressed: () {
+                              showDialog(
+                                context: context,
+                                barrierColor: Colors.black.withValues(alpha: 0.5),
+                                builder: (context) =>
+                                    SettingsPlaybackEditInstanceUrlDialog(
+                                  title: "音乐API代理",
+                                  initialValue: preferences.chineseMusicProxyUrl ?? "",
+                                  onSave: (value) {
+                                    preferencesNotifier.setChineseMusicProxyUrl(
+                                      value.isEmpty ? null : value,
+                                    );
+                                  },
+                                ),
+                              );
+                            },
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ],
             ),
           _ => const SizedBox.shrink(),
         },

--- a/lib/provider/user_preferences/user_preferences_provider.dart
+++ b/lib/provider/user_preferences/user_preferences_provider.dart
@@ -195,6 +195,10 @@ class UserPreferencesNotifier extends Notifier<PreferencesTableData> {
     setData(PreferencesTableCompanion(invidiousInstance: Value(instance)));
   }
 
+  void setChineseMusicProxyUrl(String? url) {
+    setData(PreferencesTableCompanion(chineseMusicProxyUrl: Value(url)));
+  }
+
   void setSearchMode(SearchMode mode) {
     setData(PreferencesTableCompanion(searchMode: Value(mode)));
   }

--- a/lib/services/chinese_music_proxy/chinese_music_proxy.dart
+++ b/lib/services/chinese_music_proxy/chinese_music_proxy.dart
@@ -1,0 +1,175 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:crypto/crypto.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spotube/provider/user_preferences/user_preferences_provider.dart';
+
+final chineseMusicProxyProvider = Provider<ChineseMusicProxy>((ref) {
+  return ChineseMusicProxy(ref);
+});
+
+class ChineseMusicProxy {
+  final Ref ref;
+  
+  ChineseMusicProxy(this.ref);
+  
+  // Base URL for the proxy server
+  String get _baseUrl {
+    final preferences = ref.read(userPreferencesProvider);
+    return preferences.chineseMusicProxyUrl ?? 'https://music-api.example.com';
+  }
+  
+  // Check if proxy URL is configured
+  bool get isProxyConfigured {
+    final preferences = ref.read(userPreferencesProvider);
+    return preferences.chineseMusicProxyUrl != null;
+  }
+  
+  // Headers for API requests
+  Map<String, String> get _headers => {
+    'Content-Type': 'application/json',
+    'User-Agent': 'Spotube/1.0',
+  };
+  
+  // Generate a signature for request authentication
+  String _generateSignature(Map<String, dynamic> params, String timestamp) {
+    final sortedKeys = params.keys.toList()..sort();
+    final sortedParams = <String, dynamic>{};
+    for (final key in sortedKeys) {
+      sortedParams[key] = params[key];
+    }
+    
+    final paramsString = sortedParams.entries
+        .map((e) => '${e.key}=${e.value}')
+        .join('&');
+    
+    final signString = '$paramsString&timestamp=$timestamp';
+    final secretKey = 'your_secret_key'; // This would be stored securely
+    
+    final hmacSha256 = Hmac(sha256, utf8.encode(secretKey));
+    final digest = hmacSha256.convert(utf8.encode(signString));
+    
+    return digest.toString();
+  }
+  
+  // Check if the proxy server is working
+  Future<bool> checkProxyStatus() async {
+    if (!isProxyConfigured) return false;
+    
+    try {
+      final response = await http.get(
+        Uri.parse('$_baseUrl/status'),
+        headers: _headers,
+      ).timeout(const Duration(seconds: 5));
+      
+      return response.statusCode == 200;
+    } catch (e) {
+      return false;
+    }
+  }
+  
+  // Search for music on Chinese platforms
+  Future<Map<String, dynamic>> searchMusic({
+    required String platform,
+    required String keyword,
+    int page = 1,
+    int limit = 10,
+  }) async {
+    final timestamp = DateTime.now().millisecondsSinceEpoch.toString();
+    final params = {
+      'platform': platform,
+      'keyword': keyword,
+      'page': page.toString(),
+      'limit': limit.toString(),
+    };
+    
+    final signature = _generateSignature(params, timestamp);
+    
+    final response = await http.post(
+      Uri.parse('$_baseUrl/search'),
+      headers: {
+        ..._headers,
+        'X-Timestamp': timestamp,
+        'X-Signature': signature,
+      },
+      body: jsonEncode({
+        ...params,
+        'timestamp': timestamp,
+      }),
+    );
+    
+    if (response.statusCode != 200) {
+      throw Exception('Failed to search music: ${response.body}');
+    }
+    
+    return jsonDecode(response.body);
+  }
+  
+  // Get music URL from Chinese platforms
+  Future<Map<String, dynamic>> getMusicUrl({
+    required String platform,
+    required String songId,
+    required String quality,
+  }) async {
+    final timestamp = DateTime.now().millisecondsSinceEpoch.toString();
+    final params = {
+      'platform': platform,
+      'songId': songId,
+      'quality': quality,
+    };
+    
+    final signature = _generateSignature(params, timestamp);
+    
+    final response = await http.post(
+      Uri.parse('$_baseUrl/url'),
+      headers: {
+        ..._headers,
+        'X-Timestamp': timestamp,
+        'X-Signature': signature,
+      },
+      body: jsonEncode({
+        ...params,
+        'timestamp': timestamp,
+      }),
+    );
+    
+    if (response.statusCode != 200) {
+      throw Exception('Failed to get music URL: ${response.body}');
+    }
+    
+    return jsonDecode(response.body);
+  }
+  
+  // Get lyrics from Chinese platforms
+  Future<Map<String, dynamic>> getLyric({
+    required String platform,
+    required String songId,
+  }) async {
+    final timestamp = DateTime.now().millisecondsSinceEpoch.toString();
+    final params = {
+      'platform': platform,
+      'songId': songId,
+    };
+    
+    final signature = _generateSignature(params, timestamp);
+    
+    final response = await http.post(
+      Uri.parse('$_baseUrl/lyric'),
+      headers: {
+        ..._headers,
+        'X-Timestamp': timestamp,
+        'X-Signature': signature,
+      },
+      body: jsonEncode({
+        ...params,
+        'timestamp': timestamp,
+      }),
+    );
+    
+    if (response.statusCode != 200) {
+      throw Exception('Failed to get lyrics: ${response.body}');
+    }
+    
+    return jsonDecode(response.body);
+  }
+}

--- a/lib/services/sourced_track/sourced_track.dart
+++ b/lib/services/sourced_track/sourced_track.dart
@@ -10,6 +10,8 @@ import 'package:spotube/services/sourced_track/sources/invidious.dart';
 import 'package:spotube/services/sourced_track/sources/jiosaavn.dart';
 import 'package:spotube/services/sourced_track/sources/piped.dart';
 import 'package:spotube/services/sourced_track/sources/youtube.dart';
+// Import Chinese music sources
+import 'package:spotube/services/sourced_track/sources/chinese/index.dart';
 import 'package:spotube/utils/service_utils.dart';
 
 abstract class SourcedTrack extends Track {
@@ -86,6 +88,42 @@ abstract class SourcedTrack extends Track {
           sourceInfo: sourceInfo,
           track: track,
         ),
+      // Chinese music platforms
+      AudioSource.kw => KWSourcedTrack(
+          ref: ref,
+          source: source,
+          siblings: siblings,
+          sourceInfo: sourceInfo,
+          track: track,
+        ),
+      AudioSource.kg => KGSourcedTrack(
+          ref: ref,
+          source: source,
+          siblings: siblings,
+          sourceInfo: sourceInfo,
+          track: track,
+        ),
+      AudioSource.tx => TXSourcedTrack(
+          ref: ref,
+          source: source,
+          siblings: siblings,
+          sourceInfo: sourceInfo,
+          track: track,
+        ),
+      AudioSource.wy => WYSourcedTrack(
+          ref: ref,
+          source: source,
+          siblings: siblings,
+          sourceInfo: sourceInfo,
+          track: track,
+        ),
+      AudioSource.mg => MGSourcedTrack(
+          ref: ref,
+          source: source,
+          siblings: siblings,
+          sourceInfo: sourceInfo,
+          track: track,
+        ),
     };
   }
 
@@ -117,6 +155,17 @@ abstract class SourcedTrack extends Track {
           await InvidiousSourcedTrack.fetchFromTrack(track: track, ref: ref),
         AudioSource.jiosaavn =>
           await JioSaavnSourcedTrack.fetchFromTrack(track: track, ref: ref),
+        // Chinese music platforms
+        AudioSource.kw =>
+          await KWSourcedTrack.fetchFromTrack(track: track, ref: ref),
+        AudioSource.kg =>
+          await KGSourcedTrack.fetchFromTrack(track: track, ref: ref),
+        AudioSource.tx =>
+          await TXSourcedTrack.fetchFromTrack(track: track, ref: ref),
+        AudioSource.wy =>
+          await WYSourcedTrack.fetchFromTrack(track: track, ref: ref),
+        AudioSource.mg =>
+          await MGSourcedTrack.fetchFromTrack(track: track, ref: ref),
       };
     } catch (e) {
       if (preferences.audioSource == AudioSource.youtube) {
@@ -142,6 +191,17 @@ abstract class SourcedTrack extends Track {
         JioSaavnSourcedTrack.fetchSiblings(track: track, ref: ref),
       AudioSource.invidious =>
         InvidiousSourcedTrack.fetchSiblings(track: track, ref: ref),
+      // Chinese music platforms
+      AudioSource.kw =>
+        KWSourcedTrack.fetchSiblings(track: track, ref: ref),
+      AudioSource.kg =>
+        KGSourcedTrack.fetchSiblings(track: track, ref: ref),
+      AudioSource.tx =>
+        TXSourcedTrack.fetchSiblings(track: track, ref: ref),
+      AudioSource.wy =>
+        WYSourcedTrack.fetchSiblings(track: track, ref: ref),
+      AudioSource.mg =>
+        MGSourcedTrack.fetchSiblings(track: track, ref: ref),
     };
   }
 

--- a/lib/services/sourced_track/sources/chinese/README.md
+++ b/lib/services/sourced_track/sources/chinese/README.md
@@ -1,0 +1,33 @@
+# Chinese Music Sources for Spotube
+
+This directory contains the implementation of Chinese music platforms as audio sources for Spotube.
+
+## Supported Platforms
+
+- `kw.dart` - 酷我音乐 (Kuwo Music)
+- `kg.dart` - 酷狗音乐 (Kugou Music)
+- `tx.dart` - QQ音乐 (QQ Music)
+- `wy.dart` - 网易音乐 (NetEase Music)
+- `mg.dart` - 咪咕音乐 (Migu Music)
+
+## Architecture
+
+- `base.dart` - Base class for all Chinese music sources with common methods
+- `index.dart` - Exports all Chinese music sources
+
+## How It Works
+
+1. Each platform implementation extends the `ChineseSourcedTrack` class from `base.dart`
+2. The `ChineseSourcedTrack` class provides common methods for searching music, getting URLs, and lyrics
+3. Each platform implementation provides platform-specific implementations of these methods
+4. All API requests are proxied through a server configured by the user
+
+## API Proxy
+
+The Chinese music sources require a proxy server to handle API requests to Chinese music platforms. This is configured in the `ChineseMusicProxy` class.
+
+See the documentation in `/docs/chinese_music_sources.md` for more information on setting up a proxy server.
+
+## Credits
+
+This implementation was inspired by and adapted from the [lx-music-desktop](https://github.com/lyswhut/lx-music-desktop) project.

--- a/lib/services/sourced_track/sources/chinese/base.dart
+++ b/lib/services/sourced_track/sources/chinese/base.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spotify/spotify.dart';
+import 'package:spotube/models/database/database.dart';
+import 'package:spotube/services/chinese_music_proxy/chinese_music_proxy.dart';
+import 'package:spotube/services/sourced_track/enums.dart';
+import 'package:spotube/services/sourced_track/models/source_info.dart';
+import 'package:spotube/services/sourced_track/models/source_map.dart';
+import 'package:spotube/services/sourced_track/sourced_track.dart';
+
+abstract class ChineseSourcedTrack extends SourcedTrack {
+  ChineseSourcedTrack({
+    required super.ref,
+    required super.source,
+    required super.siblings,
+    required super.sourceInfo,
+    required super.track,
+  });
+
+  // Common method to search for music across Chinese platforms
+  static Future<Map<String, dynamic>> searchMusic({
+    required String platform,
+    required String keyword,
+    required Ref ref,
+    int page = 1,
+    int limit = 10,
+  }) async {
+    final proxy = ref.read(chineseMusicProxyProvider);
+    
+    return await proxy.searchMusic(
+      platform: platform,
+      keyword: keyword,
+      page: page,
+      limit: limit,
+    );
+  }
+
+  // Common method to get music URL across Chinese platforms
+  static Future<Map<String, dynamic>> getMusicUrl({
+    required String platform,
+    required String songId,
+    required String quality,
+    required Ref ref,
+  }) async {
+    final proxy = ref.read(chineseMusicProxyProvider);
+    
+    return await proxy.getMusicUrl(
+      platform: platform,
+      songId: songId,
+      quality: quality,
+    );
+  }
+
+  // Common method to get lyrics across Chinese platforms
+  static Future<Map<String, dynamic>> getLyric({
+    required String platform,
+    required String songId,
+    required Ref ref,
+  }) async {
+    final proxy = ref.read(chineseMusicProxyProvider);
+    
+    return await proxy.getLyric(
+      platform: platform,
+      songId: songId,
+    );
+  }
+  
+  // Helper method to convert quality to platform-specific format
+  static String mapQuality(SourceQualities quality, String platform) {
+    switch (platform) {
+      case 'kw':
+        return switch (quality) {
+          SourceQualities.high => '320',
+          SourceQualities.medium => '192',
+          SourceQualities.low => '128',
+        };
+      case 'kg':
+        return switch (quality) {
+          SourceQualities.high => '320',
+          SourceQualities.medium => '192',
+          SourceQualities.low => '128',
+        };
+      case 'tx':
+        return switch (quality) {
+          SourceQualities.high => '320',
+          SourceQualities.medium => '192',
+          SourceQualities.low => '128',
+        };
+      case 'wy':
+        return switch (quality) {
+          SourceQualities.high => '320000',
+          SourceQualities.medium => '192000',
+          SourceQualities.low => '128000',
+        };
+      case 'mg':
+        return switch (quality) {
+          SourceQualities.high => 'flac',
+          SourceQualities.medium => '320',
+          SourceQualities.low => '128',
+        };
+      default:
+        return '320';
+    }
+  }
+}

--- a/lib/services/sourced_track/sources/chinese/index.dart
+++ b/lib/services/sourced_track/sources/chinese/index.dart
@@ -1,0 +1,6 @@
+export 'kw.dart';
+export 'kg.dart';
+export 'tx.dart';
+export 'wy.dart';
+export 'mg.dart';
+export 'base.dart';

--- a/lib/services/sourced_track/sources/chinese/kg.dart
+++ b/lib/services/sourced_track/sources/chinese/kg.dart
@@ -1,0 +1,171 @@
+import 'dart:convert';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spotify/spotify.dart';
+import 'package:spotube/models/database/database.dart';
+import 'package:spotube/services/sourced_track/enums.dart';
+import 'package:spotube/services/sourced_track/models/source_info.dart';
+import 'package:spotube/services/sourced_track/models/source_map.dart';
+import 'package:spotube/services/sourced_track/sourced_track.dart';
+import 'package:spotube/services/sourced_track/sources/chinese/base.dart';
+
+class KGSourcedTrack extends ChineseSourcedTrack {
+  KGSourcedTrack({
+    required super.ref,
+    required super.source,
+    required super.siblings,
+    required super.sourceInfo,
+    required super.track,
+  });
+
+  static Future<KGSourcedTrack> fetchFromTrack({
+    required Track track,
+    required Ref ref,
+  }) async {
+    final searchTerm = SourcedTrack.getSearchTerm(track);
+    
+    final data = await ChineseSourcedTrack.searchMusic(
+      platform: 'kg',
+      keyword: searchTerm,
+      ref: ref,
+      limit: 10,
+    );
+    
+    if (data['list'] == null || data['list'].isEmpty) {
+      throw Exception('No results found for: $searchTerm');
+    }
+    
+    final firstResult = data['list'][0];
+    final songId = firstResult['hash'];
+    
+    // Get music URL for different qualities
+    final urlData = await ChineseSourcedTrack.getMusicUrl(
+      platform: 'kg',
+      songId: songId,
+      quality: ChineseSourcedTrack.mapQuality(SourceQualities.high, 'kg'),
+      ref: ref,
+    );
+    
+    // Create source map with available qualities
+    final sourceMap = SourceMap({
+      SourceCodecs.m4a: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+      SourceCodecs.weba: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+    });
+    
+    // Create source info
+    final sourceInfo = SourceInfo(
+      id: songId,
+      title: firstResult['songname'],
+      author: firstResult['singername'],
+      duration: Duration(milliseconds: int.parse(firstResult['duration'] ?? '0') * 1000),
+      thumbnails: [firstResult['album_img'] ?? ''],
+    );
+    
+    // Get siblings (alternative versions)
+    final siblings = <SourceInfo>[];
+    for (var i = 1; i < data['list'].length && i < 5; i++) {
+      final item = data['list'][i];
+      siblings.add(
+        SourceInfo(
+          id: item['hash'],
+          title: item['songname'],
+          author: item['singername'],
+          duration: Duration(milliseconds: int.parse(item['duration'] ?? '0') * 1000),
+          thumbnails: [item['album_img'] ?? ''],
+        ),
+      );
+    }
+    
+    return KGSourcedTrack(
+      ref: ref,
+      source: sourceMap,
+      siblings: siblings,
+      sourceInfo: sourceInfo,
+      track: track,
+    );
+  }
+
+  static Future<List<SiblingType>> fetchSiblings({
+    required Track track,
+    required Ref ref,
+  }) async {
+    final searchTerm = SourcedTrack.getSearchTerm(track);
+    
+    final data = await ChineseSourcedTrack.searchMusic(
+      platform: 'kg',
+      keyword: searchTerm,
+      ref: ref,
+      limit: 10,
+    );
+    if (data['list'] == null || data['list'].isEmpty) {
+      return [];
+    }
+    
+    final siblings = <SiblingType>[];
+    
+    for (var item in data['list']) {
+      siblings.add((
+        info: SourceInfo(
+          id: item['hash'],
+          title: item['songname'],
+          author: item['singername'],
+          duration: Duration(milliseconds: int.parse(item['duration'] ?? '0') * 1000),
+          thumbnails: [item['album_img'] ?? ''],
+        ),
+        source: null,
+      ));
+    }
+    
+    return siblings;
+  }
+
+  @override
+  Future<SourcedTrack> copyWithSibling() async {
+    return this;
+  }
+
+  @override
+  Future<SourcedTrack?> swapWithSibling(SourceInfo sibling) async {
+    // Get music URL for the sibling
+    final urlData = await ChineseSourcedTrack.getMusicUrl(
+      platform: 'kg',
+      songId: sibling.id,
+      quality: ChineseSourcedTrack.mapQuality(SourceQualities.high, 'kg'),
+      ref: ref,
+    );
+    
+    // Create source map with available qualities
+    final sourceMap = SourceMap({
+      SourceCodecs.m4a: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+      SourceCodecs.weba: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+    });
+    
+    // Create new siblings list without the current sibling
+    final newSiblings = [...siblings];
+    newSiblings.add(sourceInfo);
+    newSiblings.removeWhere((s) => s.id == sibling.id);
+    
+    return KGSourcedTrack(
+      ref: ref,
+      source: sourceMap,
+      siblings: newSiblings,
+      sourceInfo: sibling,
+      track: this,
+    );
+  }
+}

--- a/lib/services/sourced_track/sources/chinese/kw.dart
+++ b/lib/services/sourced_track/sources/chinese/kw.dart
@@ -1,0 +1,171 @@
+import 'dart:convert';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spotify/spotify.dart';
+import 'package:spotube/models/database/database.dart';
+import 'package:spotube/services/sourced_track/enums.dart';
+import 'package:spotube/services/sourced_track/models/source_info.dart';
+import 'package:spotube/services/sourced_track/models/source_map.dart';
+import 'package:spotube/services/sourced_track/sourced_track.dart';
+import 'package:spotube/services/sourced_track/sources/chinese/base.dart';
+
+class KWSourcedTrack extends ChineseSourcedTrack {
+  KWSourcedTrack({
+    required super.ref,
+    required super.source,
+    required super.siblings,
+    required super.sourceInfo,
+    required super.track,
+  });
+
+  static Future<KWSourcedTrack> fetchFromTrack({
+    required Track track,
+    required Ref ref,
+  }) async {
+    final searchTerm = SourcedTrack.getSearchTerm(track);
+    
+    final data = await ChineseSourcedTrack.searchMusic(
+      platform: 'kw',
+      keyword: searchTerm,
+      ref: ref,
+      limit: 10,
+    );
+    
+    if (data['list'] == null || data['list'].isEmpty) {
+      throw Exception('No results found for: $searchTerm');
+    }
+    
+    final firstResult = data['list'][0];
+    final songId = firstResult['songmid'];
+    
+    // Get music URL for different qualities
+    final urlData = await ChineseSourcedTrack.getMusicUrl(
+      platform: 'kw',
+      songId: songId,
+      quality: ChineseSourcedTrack.mapQuality(SourceQualities.high, 'kw'),
+      ref: ref,
+    );
+    
+    // Create source map with available qualities
+    final sourceMap = SourceMap({
+      SourceCodecs.m4a: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+      SourceCodecs.weba: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+    });
+    
+    // Create source info
+    final sourceInfo = SourceInfo(
+      id: songId,
+      title: firstResult['name'],
+      author: firstResult['singer'],
+      duration: Duration(milliseconds: int.parse(firstResult['duration'] ?? '0')),
+      thumbnails: [firstResult['pic'] ?? ''],
+    );
+    
+    // Get siblings (alternative versions)
+    final siblings = <SourceInfo>[];
+    for (var i = 1; i < data['list'].length && i < 5; i++) {
+      final item = data['list'][i];
+      siblings.add(
+        SourceInfo(
+          id: item['songmid'],
+          title: item['name'],
+          author: item['singer'],
+          duration: Duration(milliseconds: int.parse(item['duration'] ?? '0')),
+          thumbnails: [item['pic'] ?? ''],
+        ),
+      );
+    }
+    
+    return KWSourcedTrack(
+      ref: ref,
+      source: sourceMap,
+      siblings: siblings,
+      sourceInfo: sourceInfo,
+      track: track,
+    );
+  }
+
+  static Future<List<SiblingType>> fetchSiblings({
+    required Track track,
+    required Ref ref,
+  }) async {
+    final searchTerm = SourcedTrack.getSearchTerm(track);
+    
+    final data = await ChineseSourcedTrack.searchMusic(
+      platform: 'kw',
+      keyword: searchTerm,
+      ref: ref,
+      limit: 10,
+    );
+    if (data['list'] == null || data['list'].isEmpty) {
+      return [];
+    }
+    
+    final siblings = <SiblingType>[];
+    
+    for (var item in data['list']) {
+      siblings.add((
+        info: SourceInfo(
+          id: item['songmid'],
+          title: item['name'],
+          author: item['singer'],
+          duration: Duration(milliseconds: int.parse(item['duration'] ?? '0')),
+          thumbnails: [item['pic'] ?? ''],
+        ),
+        source: null,
+      ));
+    }
+    
+    return siblings;
+  }
+
+  @override
+  Future<SourcedTrack> copyWithSibling() async {
+    return this;
+  }
+
+  @override
+  Future<SourcedTrack?> swapWithSibling(SourceInfo sibling) async {
+    // Get music URL for the sibling
+    final urlData = await ChineseSourcedTrack.getMusicUrl(
+      platform: 'kw',
+      songId: sibling.id,
+      quality: ChineseSourcedTrack.mapQuality(SourceQualities.high, 'kw'),
+      ref: ref,
+    );
+    
+    // Create source map with available qualities
+    final sourceMap = SourceMap({
+      SourceCodecs.m4a: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+      SourceCodecs.weba: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+    });
+    
+    // Create new siblings list without the current sibling
+    final newSiblings = [...siblings];
+    newSiblings.add(sourceInfo);
+    newSiblings.removeWhere((s) => s.id == sibling.id);
+    
+    return KWSourcedTrack(
+      ref: ref,
+      source: sourceMap,
+      siblings: newSiblings,
+      sourceInfo: sibling,
+      track: this,
+    );
+  }
+}

--- a/lib/services/sourced_track/sources/chinese/mg.dart
+++ b/lib/services/sourced_track/sources/chinese/mg.dart
@@ -1,0 +1,171 @@
+import 'dart:convert';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spotify/spotify.dart';
+import 'package:spotube/models/database/database.dart';
+import 'package:spotube/services/sourced_track/enums.dart';
+import 'package:spotube/services/sourced_track/models/source_info.dart';
+import 'package:spotube/services/sourced_track/models/source_map.dart';
+import 'package:spotube/services/sourced_track/sourced_track.dart';
+import 'package:spotube/services/sourced_track/sources/chinese/base.dart';
+
+class MGSourcedTrack extends ChineseSourcedTrack {
+  MGSourcedTrack({
+    required super.ref,
+    required super.source,
+    required super.siblings,
+    required super.sourceInfo,
+    required super.track,
+  });
+
+  static Future<MGSourcedTrack> fetchFromTrack({
+    required Track track,
+    required Ref ref,
+  }) async {
+    final searchTerm = SourcedTrack.getSearchTerm(track);
+    
+    final data = await ChineseSourcedTrack.searchMusic(
+      platform: 'mg',
+      keyword: searchTerm,
+      ref: ref,
+      limit: 10,
+    );
+    
+    if (data['musics'] == null || data['musics'].isEmpty) {
+      throw Exception('No results found for: $searchTerm');
+    }
+    
+    final firstResult = data['musics'][0];
+    final songId = firstResult['copyrightId'];
+    
+    // Get music URL for different qualities
+    final urlData = await ChineseSourcedTrack.getMusicUrl(
+      platform: 'mg',
+      songId: songId,
+      quality: ChineseSourcedTrack.mapQuality(SourceQualities.high, 'mg'),
+      ref: ref,
+    );
+    
+    // Create source map with available qualities
+    final sourceMap = SourceMap({
+      SourceCodecs.m4a: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+      SourceCodecs.weba: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+    });
+    
+    // Create source info
+    final sourceInfo = SourceInfo(
+      id: songId,
+      title: firstResult['songName'],
+      author: firstResult['singerName'],
+      duration: Duration(seconds: int.parse(firstResult['length'] ?? '0')),
+      thumbnails: [firstResult['cover'] ?? ''],
+    );
+    
+    // Get siblings (alternative versions)
+    final siblings = <SourceInfo>[];
+    for (var i = 1; i < data['musics'].length && i < 5; i++) {
+      final item = data['musics'][i];
+      siblings.add(
+        SourceInfo(
+          id: item['copyrightId'],
+          title: item['songName'],
+          author: item['singerName'],
+          duration: Duration(seconds: int.parse(item['length'] ?? '0')),
+          thumbnails: [item['cover'] ?? ''],
+        ),
+      );
+    }
+    
+    return MGSourcedTrack(
+      ref: ref,
+      source: sourceMap,
+      siblings: siblings,
+      sourceInfo: sourceInfo,
+      track: track,
+    );
+  }
+
+  static Future<List<SiblingType>> fetchSiblings({
+    required Track track,
+    required Ref ref,
+  }) async {
+    final searchTerm = SourcedTrack.getSearchTerm(track);
+    
+    final data = await ChineseSourcedTrack.searchMusic(
+      platform: 'mg',
+      keyword: searchTerm,
+      ref: ref,
+      limit: 10,
+    );
+    if (data['musics'] == null || data['musics'].isEmpty) {
+      return [];
+    }
+    
+    final siblings = <SiblingType>[];
+    
+    for (var item in data['musics']) {
+      siblings.add((
+        info: SourceInfo(
+          id: item['copyrightId'],
+          title: item['songName'],
+          author: item['singerName'],
+          duration: Duration(seconds: int.parse(item['length'] ?? '0')),
+          thumbnails: [item['cover'] ?? ''],
+        ),
+        source: null,
+      ));
+    }
+    
+    return siblings;
+  }
+
+  @override
+  Future<SourcedTrack> copyWithSibling() async {
+    return this;
+  }
+
+  @override
+  Future<SourcedTrack?> swapWithSibling(SourceInfo sibling) async {
+    // Get music URL for the sibling
+    final urlData = await ChineseSourcedTrack.getMusicUrl(
+      platform: 'mg',
+      songId: sibling.id,
+      quality: ChineseSourcedTrack.mapQuality(SourceQualities.high, 'mg'),
+      ref: ref,
+    );
+    
+    // Create source map with available qualities
+    final sourceMap = SourceMap({
+      SourceCodecs.m4a: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+      SourceCodecs.weba: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+    });
+    
+    // Create new siblings list without the current sibling
+    final newSiblings = [...siblings];
+    newSiblings.add(sourceInfo);
+    newSiblings.removeWhere((s) => s.id == sibling.id);
+    
+    return MGSourcedTrack(
+      ref: ref,
+      source: sourceMap,
+      siblings: newSiblings,
+      sourceInfo: sibling,
+      track: this,
+    );
+  }
+}

--- a/lib/services/sourced_track/sources/chinese/tx.dart
+++ b/lib/services/sourced_track/sources/chinese/tx.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spotify/spotify.dart';
+import 'package:spotube/models/database/database.dart';
+import 'package:spotube/services/sourced_track/enums.dart';
+import 'package:spotube/services/sourced_track/models/source_info.dart';
+import 'package:spotube/services/sourced_track/models/source_map.dart';
+import 'package:spotube/services/sourced_track/sourced_track.dart';
+import 'package:spotube/services/sourced_track/sources/chinese/base.dart';
+
+class TXSourcedTrack extends ChineseSourcedTrack {
+  TXSourcedTrack({
+    required super.ref,
+    required super.source,
+    required super.siblings,
+    required super.sourceInfo,
+    required super.track,
+  });
+
+  static Future<TXSourcedTrack> fetchFromTrack({
+    required Track track,
+    required Ref ref,
+  }) async {
+    final searchTerm = SourcedTrack.getSearchTerm(track);
+    
+    final data = await ChineseSourcedTrack.searchMusic(
+      platform: 'tx',
+      keyword: searchTerm,
+      ref: ref,
+      limit: 10,
+    );
+    
+    if (data['list'] == null || data['list'].isEmpty) {
+      throw Exception('No results found for: $searchTerm');
+    }
+    
+    final firstResult = data['list'][0];
+    final songId = firstResult['songmid'];
+    
+    // Get music URL for different qualities
+    final urlData = await ChineseSourcedTrack.getMusicUrl(
+      platform: 'tx',
+      songId: songId,
+      quality: ChineseSourcedTrack.mapQuality(SourceQualities.high, 'tx'),
+      ref: ref,
+    );
+    
+    // Create source map with available qualities
+    final sourceMap = SourceMap({
+      SourceCodecs.m4a: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+      SourceCodecs.weba: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+    });
+    
+    // Create source info
+    final sourceInfo = SourceInfo(
+      id: songId,
+      title: firstResult['name'],
+      author: firstResult['singer'].map((s) => s['name']).join(', '),
+      duration: Duration(milliseconds: int.parse(firstResult['interval'] ?? '0') * 1000),
+      thumbnails: [firstResult['albummid'] != null 
+        ? 'https://y.gtimg.cn/music/photo_new/T002R300x300M000${firstResult['albummid']}.jpg' 
+        : ''],
+    );
+    
+    // Get siblings (alternative versions)
+    final siblings = <SourceInfo>[];
+    for (var i = 1; i < data['list'].length && i < 5; i++) {
+      final item = data['list'][i];
+      siblings.add(
+        SourceInfo(
+          id: item['songmid'],
+          title: item['name'],
+          author: item['singer'].map((s) => s['name']).join(', '),
+          duration: Duration(milliseconds: int.parse(item['interval'] ?? '0') * 1000),
+          thumbnails: [item['albummid'] != null 
+            ? 'https://y.gtimg.cn/music/photo_new/T002R300x300M000${item['albummid']}.jpg' 
+            : ''],
+        ),
+      );
+    }
+    
+    return TXSourcedTrack(
+      ref: ref,
+      source: sourceMap,
+      siblings: siblings,
+      sourceInfo: sourceInfo,
+      track: track,
+    );
+  }
+
+  static Future<List<SiblingType>> fetchSiblings({
+    required Track track,
+    required Ref ref,
+  }) async {
+    final searchTerm = SourcedTrack.getSearchTerm(track);
+    
+    final data = await ChineseSourcedTrack.searchMusic(
+      platform: 'tx',
+      keyword: searchTerm,
+      ref: ref,
+      limit: 10,
+    );
+    if (data['list'] == null || data['list'].isEmpty) {
+      return [];
+    }
+    
+    final siblings = <SiblingType>[];
+    
+    for (var item in data['list']) {
+      siblings.add((
+        info: SourceInfo(
+          id: item['songmid'],
+          title: item['name'],
+          author: item['singer'].map((s) => s['name']).join(', '),
+          duration: Duration(milliseconds: int.parse(item['interval'] ?? '0') * 1000),
+          thumbnails: [item['albummid'] != null 
+            ? 'https://y.gtimg.cn/music/photo_new/T002R300x300M000${item['albummid']}.jpg' 
+            : ''],
+        ),
+        source: null,
+      ));
+    }
+    
+    return siblings;
+  }
+
+  @override
+  Future<SourcedTrack> copyWithSibling() async {
+    return this;
+  }
+
+  @override
+  Future<SourcedTrack?> swapWithSibling(SourceInfo sibling) async {
+    // Get music URL for the sibling
+    final urlData = await ChineseSourcedTrack.getMusicUrl(
+      platform: 'tx',
+      songId: sibling.id,
+      quality: ChineseSourcedTrack.mapQuality(SourceQualities.high, 'tx'),
+      ref: ref,
+    );
+    
+    // Create source map with available qualities
+    final sourceMap = SourceMap({
+      SourceCodecs.m4a: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+      SourceCodecs.weba: {
+        SourceQualities.high: urlData['url'],
+        SourceQualities.medium: urlData['url'],
+        SourceQualities.low: urlData['url'],
+      },
+    });
+    
+    // Create new siblings list without the current sibling
+    final newSiblings = [...siblings];
+    newSiblings.add(sourceInfo);
+    newSiblings.removeWhere((s) => s.id == sibling.id);
+    
+    return TXSourcedTrack(
+      ref: ref,
+      source: sourceMap,
+      siblings: newSiblings,
+      sourceInfo: sibling,
+      track: this,
+    );
+  }
+}

--- a/lib/services/sourced_track/sources/chinese/wy.dart
+++ b/lib/services/sourced_track/sources/chinese/wy.dart
@@ -1,0 +1,171 @@
+import 'dart:convert';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spotify/spotify.dart';
+import 'package:spotube/models/database/database.dart';
+import 'package:spotube/services/sourced_track/enums.dart';
+import 'package:spotube/services/sourced_track/models/source_info.dart';
+import 'package:spotube/services/sourced_track/models/source_map.dart';
+import 'package:spotube/services/sourced_track/sourced_track.dart';
+import 'package:spotube/services/sourced_track/sources/chinese/base.dart';
+
+class WYSourcedTrack extends ChineseSourcedTrack {
+  WYSourcedTrack({
+    required super.ref,
+    required super.source,
+    required super.siblings,
+    required super.sourceInfo,
+    required super.track,
+  });
+
+  static Future<WYSourcedTrack> fetchFromTrack({
+    required Track track,
+    required Ref ref,
+  }) async {
+    final searchTerm = SourcedTrack.getSearchTerm(track);
+    
+    final data = await ChineseSourcedTrack.searchMusic(
+      platform: 'wy',
+      keyword: searchTerm,
+      ref: ref,
+      limit: 10,
+    );
+    
+    if (data['result'] == null || data['result']['songs'] == null || data['result']['songs'].isEmpty) {
+      throw Exception('No results found for: $searchTerm');
+    }
+    
+    final firstResult = data['result']['songs'][0];
+    final songId = firstResult['id'].toString();
+    
+    // Get music URL for different qualities
+    final urlData = await ChineseSourcedTrack.getMusicUrl(
+      platform: 'wy',
+      songId: songId,
+      quality: ChineseSourcedTrack.mapQuality(SourceQualities.high, 'wy'),
+      ref: ref,
+    );
+    
+    // Create source map with available qualities
+    final sourceMap = SourceMap({
+      SourceCodecs.m4a: {
+        SourceQualities.high: urlData['data'][0]['url'],
+        SourceQualities.medium: urlData['data'][0]['url'],
+        SourceQualities.low: urlData['data'][0]['url'],
+      },
+      SourceCodecs.weba: {
+        SourceQualities.high: urlData['data'][0]['url'],
+        SourceQualities.medium: urlData['data'][0]['url'],
+        SourceQualities.low: urlData['data'][0]['url'],
+      },
+    });
+    
+    // Create source info
+    final sourceInfo = SourceInfo(
+      id: songId,
+      title: firstResult['name'],
+      author: firstResult['artists'].map((a) => a['name']).join(', '),
+      duration: Duration(milliseconds: firstResult['duration']),
+      thumbnails: [firstResult['album']['picUrl'] ?? ''],
+    );
+    
+    // Get siblings (alternative versions)
+    final siblings = <SourceInfo>[];
+    for (var i = 1; i < data['result']['songs'].length && i < 5; i++) {
+      final item = data['result']['songs'][i];
+      siblings.add(
+        SourceInfo(
+          id: item['id'].toString(),
+          title: item['name'],
+          author: item['artists'].map((a) => a['name']).join(', '),
+          duration: Duration(milliseconds: item['duration']),
+          thumbnails: [item['album']['picUrl'] ?? ''],
+        ),
+      );
+    }
+    
+    return WYSourcedTrack(
+      ref: ref,
+      source: sourceMap,
+      siblings: siblings,
+      sourceInfo: sourceInfo,
+      track: track,
+    );
+  }
+
+  static Future<List<SiblingType>> fetchSiblings({
+    required Track track,
+    required Ref ref,
+  }) async {
+    final searchTerm = SourcedTrack.getSearchTerm(track);
+    
+    final data = await ChineseSourcedTrack.searchMusic(
+      platform: 'wy',
+      keyword: searchTerm,
+      ref: ref,
+      limit: 10,
+    );
+    if (data['result'] == null || data['result']['songs'] == null || data['result']['songs'].isEmpty) {
+      return [];
+    }
+    
+    final siblings = <SiblingType>[];
+    
+    for (var item in data['result']['songs']) {
+      siblings.add((
+        info: SourceInfo(
+          id: item['id'].toString(),
+          title: item['name'],
+          author: item['artists'].map((a) => a['name']).join(', '),
+          duration: Duration(milliseconds: item['duration']),
+          thumbnails: [item['album']['picUrl'] ?? ''],
+        ),
+        source: null,
+      ));
+    }
+    
+    return siblings;
+  }
+
+  @override
+  Future<SourcedTrack> copyWithSibling() async {
+    return this;
+  }
+
+  @override
+  Future<SourcedTrack?> swapWithSibling(SourceInfo sibling) async {
+    // Get music URL for the sibling
+    final urlData = await ChineseSourcedTrack.getMusicUrl(
+      platform: 'wy',
+      songId: sibling.id,
+      quality: ChineseSourcedTrack.mapQuality(SourceQualities.high, 'wy'),
+      ref: ref,
+    );
+    
+    // Create source map with available qualities
+    final sourceMap = SourceMap({
+      SourceCodecs.m4a: {
+        SourceQualities.high: urlData['data'][0]['url'],
+        SourceQualities.medium: urlData['data'][0]['url'],
+        SourceQualities.low: urlData['data'][0]['url'],
+      },
+      SourceCodecs.weba: {
+        SourceQualities.high: urlData['data'][0]['url'],
+        SourceQualities.medium: urlData['data'][0]['url'],
+        SourceQualities.low: urlData['data'][0]['url'],
+      },
+    });
+    
+    // Create new siblings list without the current sibling
+    final newSiblings = [...siblings];
+    newSiblings.add(sourceInfo);
+    newSiblings.removeWhere((s) => s.id == sibling.id);
+    
+    return WYSourcedTrack(
+      ref: ref,
+      source: sourceMap,
+      siblings: newSiblings,
+      sourceInfo: sibling,
+      track: this,
+    );
+  }
+}


### PR DESCRIPTION
This PR adds support for Chinese music platforms (酷我音乐, 酷狗音乐, QQ音乐, 网易音乐, 咪咕音乐) to make Spotube usable in mainland China.

## Features

- Added Chinese music platforms to AudioSource enum
- Created base class for Chinese music sources
- Implemented all Chinese sources (KW, KG, TX, WY, MG)
- Set up proxy API structure for handling requests to Chinese platforms
- Added UI for configuring the proxy server
- Added documentation and example proxy server implementation

## How to Use

1. Set up a proxy server (see docs/chinese_music_sources.md)
2. Configure the proxy URL in Spotube settings
3. Select a Chinese music platform as the audio source

This implementation was inspired by and adapted from the lx-music-desktop project.